### PR TITLE
Delete all non-certbot cronjobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,10 @@ RUN apt-get update \
         certbot tini anacron \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get autoremove -y \
-    && rm -rf /var/cache/*
+    && rm -rf /var/cache/* \
+    && mv /etc/cron.daily/0anacron /tmp \
+    && rm /etc/cron.daily/* \
+    && mv /tmp/0anacron /etc/cron.daily
 
 ADD entrypoint.sh /entrypoint.sh
 ADD certbot.cron /etc/cron.daily/certbot


### PR DESCRIPTION
Otherwise, users will face an apt-compat run which sleeps for a
random and possibly very high amount of seconds.