### PR TITLE
Add fake sendmail to show errors/log output in docker logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,6 @@ RUN apt-get update \
 
 ADD entrypoint.sh /entrypoint.sh
 ADD certbot.cron /etc/cron.daily/certbot
+ADD sendmail /usr/sbin/sendmail
 RUN chmod 555 /etc/cron.daily/certbot
 RUN useradd -md /snikket/letsencrypt letsencrypt

--- a/sendmail
+++ b/sendmail
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec cat


### PR DESCRIPTION
This helps tremendously with debugging what it does and why it
does (not) do anything.