### PR TITLE
Dockerfile: Switch base image to Debian 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG BUILD_SERIES=dev
 ARG BUILD_ID=0


### PR DESCRIPTION
Built, runs, trickier to test further from behind NAT, and risky with the rate limits. I would not expect much breakage from switching distro tho.