### PR TITLE
Improved error reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ CMD ["/bin/sh", "/entrypoint.sh"]
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        certbot tini anacron \
+        certbot tini anacron jq \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get autoremove -y \
     && rm -rf /var/cache/* \

--- a/certbot.cron
+++ b/certbot.cron
@@ -9,7 +9,6 @@ su letsencrypt -- -c "certbot certonly -n --webroot --webroot-path /var/www \
   --cert-path /etc/ssl/certbot \
   --keep $SNIKKET_CERTBOT_OPTIONS \
   --agree-tos --email \"$SNIKKET_ADMIN_EMAIL\" --expand \
-  --allow-subset-of-names \
   --config-dir /snikket/letsencrypt \
   --domain \"$SNIKKET_DOMAIN\" --domain \"share.$SNIKKET_DOMAIN\" \
   --domain \"groups.$SNIKKET_DOMAIN\"

--- a/certbot.cron
+++ b/certbot.cron
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if test -f /var/log/letsencrypt/letsencrypt.log; then
+	# Preserve previous log until next run
+	mv /var/log/letsencrypt/letsencrypt.log /var/log/letsencrypt/letsencrypt.log.old;
+fi
+
 su letsencrypt -- -c "certbot certonly -n --webroot --webroot-path /var/www \
   --cert-path /etc/ssl/certbot \
   --keep $SNIKKET_CERTBOT_OPTIONS \

--- a/certbot.cron
+++ b/certbot.cron
@@ -18,7 +18,7 @@ sed -n '/^{/,/^}/p' /var/log/letsencrypt/letsencrypt.log \
   | jq -r '(select(.status=="invalid").challenges | .[].error?.detail ), select(.detail).detail' \
   > /var/log/letsencrypt/errors.log;
 
-if ! test -s /var/log/letsencrypt/errors.log; then
+if test -s /var/log/letsencrypt/errors.log; then
 	touch /snikket/letsencrypt/has-errors;
 elif test -f /snikket/letsencrypt/has-errors; then
 	rm /snikket/letsencrypt/has-errors;

--- a/certbot.cron
+++ b/certbot.cron
@@ -14,3 +14,7 @@ su letsencrypt -- -c "certbot certonly -n --webroot --webroot-path /var/www \
   --domain \"$SNIKKET_DOMAIN\" --domain \"share.$SNIKKET_DOMAIN\" \
   --domain \"groups.$SNIKKET_DOMAIN\"
   "
+
+sed -n '/^{/,/^}/p' /var/log/letsencrypt/letsencrypt.log \
+  | jq -r '(select(.status=="invalid").challenges | .[].error?.detail ), select(.detail).detail' \
+  > /var/log/letsencrypt/errors.log;

--- a/certbot.cron
+++ b/certbot.cron
@@ -18,3 +18,9 @@ su letsencrypt -- -c "certbot certonly -n --webroot --webroot-path /var/www \
 sed -n '/^{/,/^}/p' /var/log/letsencrypt/letsencrypt.log \
   | jq -r '(select(.status=="invalid").challenges | .[].error?.detail ), select(.detail).detail' \
   > /var/log/letsencrypt/errors.log;
+
+if ! test -s /var/log/letsencrypt/errors.log; then
+	touch /snikket/letsencrypt/has-errors;
+elif test -f /snikket/letsencrypt/has-errors; then
+	rm /snikket/letsencrypt/has-errors;
+fi


### PR DESCRIPTION
This adds some improved error reporting to the certificate obtaining process. Specifically:

- The certbot log is removed before each run (so that the log always contains the results of the most recent run only)
- The certbot log is scraped for errors, and these are extracted and stored in a simple text file for easier viewing
- In case of errors, a flag file is created in the shared volume. This can be used by other containers (such as snikket-web-proxy) to notify the user about any issues.