### PR TITLE
certbot: Reuse existing key by default

### DIFF
--- a/certbot.cron
+++ b/certbot.cron
@@ -5,9 +5,11 @@ if test -f /var/log/letsencrypt/letsencrypt.log; then
 	mv /var/log/letsencrypt/letsencrypt.log /var/log/letsencrypt/letsencrypt.log.old;
 fi
 
+SNIKKET_CERTBOT_KEY_OPTIONS=${SNIKKET_CERTBOT_KEY_OPTIONS:---reuse-key}
+
 su letsencrypt -- -c "certbot certonly -n --webroot --webroot-path /var/www \
   --cert-path /etc/ssl/certbot \
-  --keep $SNIKKET_CERTBOT_OPTIONS \
+  --keep $SNIKKET_CERTBOT_OPTIONS $SNIKKET_CERTBOT_KEY_OPTIONS \
   --agree-tos --email \"$SNIKKET_ADMIN_EMAIL\" --expand \
   --config-dir /snikket/letsencrypt \
   --domain \"$SNIKKET_DOMAIN\" --domain \"share.$SNIKKET_DOMAIN\" \


### PR DESCRIPTION
This makes it more useful for things that pin based on the key, e.g. DANE.

It can be overridden by setting `SNIKKET_CERTBOT_KEY_OPTIONS=--no-reuse-key`.