### PR TITLE
Add support to wait for HTTP to be available before obtaining certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,6 @@ RUN apt-get update \
 ADD entrypoint.sh /entrypoint.sh
 ADD certbot.cron /etc/cron.daily/certbot
 ADD sendmail /usr/sbin/sendmail
+ADD wait_for_http.py /usr/local/bin/wait_for_http.py
 RUN chmod 555 /etc/cron.daily/certbot
 RUN useradd -md /snikket/letsencrypt letsencrypt

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,4 +22,8 @@ if ! chown -R letsencrypt:letsencrypt /snikket/letsencrypt; then
 	echo "WW: Failed to adjust the permissions of some files/directories";
 fi
 
+if [ "$SNIKKET_CERTS_WAIT" = "1" ]; then
+	/usr/local/bin/wait_for_http.py "http://${SNIKKET_DOMAIN}";
+fi
+
 exec /bin/sh -c "/usr/sbin/anacron -d -n && sleep 3600"

--- a/wait_for_http.py
+++ b/wait_for_http.py
@@ -1,0 +1,33 @@
+import requests
+import sys
+import time
+from datetime import datetime
+
+url = sys.argv[1]
+
+sys.stdout.write("Waiting for HTTP to be available")
+
+time_start = datetime.now()
+
+for i in range(1, 100):
+    try:
+        r = requests.head(url)
+        r.raise_for_status()
+    except requests.exceptions.HTTPError:
+        sys.stdout.write(".")
+    except requests.exceptions.ConnectionError:
+        sys.stdout.write("!")
+    else:
+        time_taken = datetime.now() - time_start
+        sys.stdout.write(
+            f"\nHTTP is available after {time_taken.seconds:0.2f}s (attempt {i})\n"
+        )
+        sys.exit(0)
+    finally:
+        sys.stdout.flush()
+        if not i % 10:
+            sys.stdout.write("\n")
+
+    time.sleep(i**0.8)
+
+sys.exit(1)


### PR DESCRIPTION
This can be useful if we're not sure that a reverse proxy is ready yet. It's disabled by default for now, but it might make sense to enable it by default in the future if testing is positive.