### PR TITLE
Option to use DNS01 challenge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+FROM rust:1.83-bookworm AS agnos
+
+RUN cargo install agnos
+
 FROM debian:bookworm-slim
 
 ARG BUILD_SERIES=dev
@@ -8,15 +12,20 @@ VOLUME ["/snikket"]
 ENTRYPOINT ["/usr/bin/tini"]
 CMD ["/bin/bash", "/entrypoint.sh"]
 
+COPY --from=agnos /usr/local/cargo/bin/agnos /usr/bin/agnos
+COPY --from=agnos /usr/local/cargo/bin/agnos-generate-accounts-keys /usr/bin/agnos-generate-accounts-keys
+
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        certbot tini anacron idn2 jq \
+        certbot tini anacron idn2 jq libcap2-bin \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get autoremove -y \
     && rm -rf /var/cache/* \
     && mv /etc/cron.daily/0anacron /tmp \
     && rm /etc/cron.daily/* /etc/cron.d/* \
     && mv /tmp/0anacron /etc/cron.daily
+
+RUN setcap 'cap_net_bind_service=+ep' /usr/bin/agnos
 
 # Required for idn2 to work, and probably generally good
 ENV LANG=C.UTF-8

--- a/certbot.cron
+++ b/certbot.cron
@@ -17,7 +17,7 @@ has_errors () {
 	return;
 }
 
-try_cert () {
+try_http01 () {
 	if su letsencrypt -- -c "certbot certonly -n --webroot --webroot-path /var/www \
 	  --cert-path /etc/ssl/certbot \
 	  --keep ${SNIKKET_CERTBOT_OPTIONS-} $SNIKKET_CERTBOT_KEY_OPTIONS \
@@ -43,6 +43,36 @@ try_cert () {
 	fi
 }
 
+
+try_dns01() {
+	cd /tmp
+	echo "dns_listen_addr = \"0.0.0.0:53\"" > agnos.toml
+	echo "[[accounts]]" >> agnos.toml
+	echo "email = \"$SNIKKET_ADMIN_EMAIL\"" >> agnos.toml
+	echo "private_key_path = \"/snikket/letsencrypt/account.pem\"" >> agnos.toml
+	echo "[[accounts.certificates]]" >> agnos.toml
+	echo "domains = [\"$SNIKKET_DOMAIN_ASCII\", \"*.$SNIKKET_DOMAIN_ASCII\"]" >> agnos.toml
+	echo "fullchain_output_file = \"/snikket/letsencrypt/live/$SNIKKET_DOMAIN_ASCII/fullchain.pem\"" >> agnos.toml
+	echo "key_output_file = \"/snikket/letsencrypt/live/$SNIKKET_DOMAIN_ASCII/privkey.pem\"" >> agnos.toml
+	install -o letsencrypt -g letsencrypt -m 750 -d "/snikket/letsencrypt/live/$SNIKKET_DOMAIN_ASCII"
+	su letsencrypt -- -c "agnos-generate-accounts-keys --no-confirm agnos.toml"
+	if su letsencrypt -- -c "agnos --no-staging agnos.toml 2>&1 > /var/log/letsencrypt/agnos.log"; then
+		grep -i error /var/log/letsencrypt/agnos.log > /var/log/letsencrypt/errors.log || true
+		rm -f /snikket/letsencrypt/has-errors
+	else
+		grep -i error /var/log/letsencrypt/agnos.log > /var/log/letsencrypt/errors.log || true
+		touch /snikket/letsencrypt/has-errors
+		report-error.sh "Certificate issuance failure" "/var/log/letsencrypt/errors.log";
+	fi
+}
+
+try_cert() {
+	if [ -z "${SNIKKET_USE_DNS01-}" ]; then
+		try_http01
+	else
+		try_dns01
+	fi
+}
 
 should_retry () {
 	# This matches certain "soft" errors that we consider safe to retry

--- a/certbot.cron
+++ b/certbot.cron
@@ -54,6 +54,11 @@ try_dns01() {
 	echo "domains = [\"$SNIKKET_DOMAIN_ASCII\", \"*.$SNIKKET_DOMAIN_ASCII\"]" >> agnos.toml
 	echo "fullchain_output_file = \"/snikket/letsencrypt/live/$SNIKKET_DOMAIN_ASCII/fullchain.pem\"" >> agnos.toml
 	echo "key_output_file = \"/snikket/letsencrypt/live/$SNIKKET_DOMAIN_ASCII/privkey.pem\"" >> agnos.toml
+	if echo "$SNIKKET_CERTBOT_KEY_OPTIONS" | grep no-reuse-key; then
+	  echo "reuse_private_key = false" >> agnos.toml
+	else
+	  echo "reuse_private_key = true" >> agnos.toml
+	fi
 	install -o letsencrypt -g letsencrypt -m 750 -d "/snikket/letsencrypt/live/$SNIKKET_DOMAIN_ASCII"
 	su letsencrypt -- -c "agnos-generate-accounts-keys --no-confirm agnos.toml"
 	if su letsencrypt -- -c "agnos --no-staging agnos.toml 2>&1 > /var/log/letsencrypt/agnos.log"; then


### PR DESCRIPTION
If SNIKKET_USE_DNS01 is set, then use agnos instead of certbot to get the certificate from letsencrypt. Puts the certificate in teh same place etc but does not require any cooperation from the HTTP server or to even have the domain's IP pointing at us at all.